### PR TITLE
Add f(x) = A*x, A\x

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,10 +6,11 @@ version = "0.1.1"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
-julia="1"
+julia = "1"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/src/DiffTests.jl
+++ b/src/DiffTests.jl
@@ -258,10 +258,6 @@ diag_matrix(::Type{T}, n::Integer) where T<:Real =
     Diagonal(LinRange(convert(T, 0.01), convert(T, 100.0), n))
 diag_matrix(x::VecOrMat) = diag_matrix(Float64, size(x, 1))
 
-hilbert_matrix(::Type{T}, n::Integer) where T<:Real =
-    [convert(T, inv(i + j - 1)) for i in 1:n, j in 1:n]
-hilbert_matrix(x::VecOrMat) = hilbert_matrix(Float64, size(x, 1))
-
 lehmer_matrix(::Type{T}, n::Integer) where T<:Real =
     [convert(T, min(i, j)/max(i, j)) for i in 1:n, j in 1:n]
 lehmer_matrix(x::VecOrMat) = lehmer_matrix(Float64, size(x, 1))

--- a/src/DiffTests.jl
+++ b/src/DiffTests.jl
@@ -307,6 +307,8 @@ const ARRAY_TO_ARRAY_FUNCS = (-, chebyquad, brown_almost_linear, trigonometric, 
 # f(::Matrix)::Matrix #
 #######################
 
-const MATRIX_TO_MATRIX_FUNCS = (inv,)
+const MATRIX_TO_MATRIX_FUNCS = (inv,
+                                diag_lmul, dense_lmul, utriag_lmul, ltriag_lmul,
+                                diag_ldiv, utriag_ldiv, ltriag_ldiv)
 
 end # module

--- a/src/DiffTests.jl
+++ b/src/DiffTests.jl
@@ -1,6 +1,6 @@
 module DiffTests
 
-using LinearAlgebra: det, norm, dot, tr
+using LinearAlgebra: det, norm, dot, tr, Diagonal, LowerTriangular, UpperTriangular
 using Statistics: mean
 
 #=
@@ -246,8 +246,41 @@ function mutation_test_2!(y, x)
     return nothing
 end
 
+############################
+# f(x::VecOrMat)::VecOrMat #
+############################
+
 const INPLACE_ARRAY_TO_ARRAY_FUNCS = (chebyquad!, brown_almost_linear!, trigonometric!,
                                       mutation_test_1!, mutation_test_2!)
+
+diag_matrix(::Type{T}, n::Integer) where T<:Real =
+    Diagonal(LinRange(convert(T, 0.01), convert(T, 100.0), n))
+diag_matrix(x::VecOrMat) = diag_matrix(Float64, size(x, 1))
+
+hilbert_matrix(::Type{T}, n::Integer) where T<:Real =
+    [convert(T, inv(i + j - 1)) for i in 1:n, j in 1:n]
+hilbert_matrix(x::VecOrMat) = hilbert_matrix(Float64, size(x, 1))
+
+lehmer_matrix(::Type{T}, n::Integer) where T<:Real =
+    [convert(T, min(i, j)/max(i, j)) for i in 1:n, j in 1:n]
+lehmer_matrix(x::VecOrMat) = lehmer_matrix(Float64, size(x, 1))
+
+test_matrix = lehmer_matrix
+
+# left multiplication by a constant matrix
+diag_lmul(x::VecOrMat) = diag_matrix(x) * x
+dense_lmul(x::VecOrMat) = test_matrix(x) * x
+utriag_lmul(x::VecOrMat) =  UpperTriangular(test_matrix(x)) * x
+ltriag_lmul(x::VecOrMat) =  LowerTriangular(test_matrix(x)) * x
+
+# left division by a constant matrix
+diag_ldiv(x::VecOrMat) = diag_matrix(x) \ x
+dense_ldiv(x::VecOrMat) = test_matrix(x) \ x
+utriag_ldiv(x::VecOrMat) =  UpperTriangular(test_matrix(x)) \ x
+ltriag_ldiv(x::VecOrMat) =  LowerTriangular(test_matrix(x)) \ x
+
+const VECTOR_TO_VECTOR_FUNCS = (diag_lmul, dense_lmul, utriag_lmul, ltriag_lmul,
+                                diag_ldiv, utriag_ldiv, ltriag_ldiv)
 
 ######################
 # f(x::Array)::Array #

--- a/src/DiffTests.jl
+++ b/src/DiffTests.jl
@@ -246,12 +246,12 @@ function mutation_test_2!(y, x)
     return nothing
 end
 
+const INPLACE_ARRAY_TO_ARRAY_FUNCS = (chebyquad!, brown_almost_linear!, trigonometric!,
+                                      mutation_test_1!, mutation_test_2!)
+
 ############################
 # f(x::VecOrMat)::VecOrMat #
 ############################
-
-const INPLACE_ARRAY_TO_ARRAY_FUNCS = (chebyquad!, brown_almost_linear!, trigonometric!,
-                                      mutation_test_1!, mutation_test_2!)
 
 diag_matrix(::Type{T}, n::Integer) where T<:Real =
     Diagonal(LinRange(convert(T, 0.01), convert(T, 100.0), n))

--- a/src/DiffTests.jl
+++ b/src/DiffTests.jl
@@ -1,6 +1,7 @@
 module DiffTests
 
 using LinearAlgebra: det, norm, dot, tr, Diagonal, LowerTriangular, UpperTriangular
+using SparseArrays: sparse
 using Statistics: mean
 
 #=
@@ -272,15 +273,23 @@ diag_lmul(x::VecOrMat) = diag_matrix(x) * x
 dense_lmul(x::VecOrMat) = test_matrix(x) * x
 utriag_lmul(x::VecOrMat) =  UpperTriangular(test_matrix(x)) * x
 ltriag_lmul(x::VecOrMat) =  LowerTriangular(test_matrix(x)) * x
+sparse_lmul(x::VecOrMat) = sparse(test_matrix(x)) * x
+sp_utriag_lmul(x::VecOrMat) = UpperTriangular(sparse(test_matrix(x))) * x
+sp_ltriag_lmul(x::VecOrMat) = LowerTriangular(sparse(test_matrix(x))) * x
 
 # left division by a constant matrix
 diag_ldiv(x::VecOrMat) = diag_matrix(x) \ x
 dense_ldiv(x::VecOrMat) = test_matrix(x) \ x
 utriag_ldiv(x::VecOrMat) =  UpperTriangular(test_matrix(x)) \ x
 ltriag_ldiv(x::VecOrMat) =  LowerTriangular(test_matrix(x)) \ x
+sparse_ldiv(x::VecOrMat) = sparse(test_matrix(x)) \ x
+sp_utriag_ldiv(x::VecOrMat) = UpperTriangular(sparse(test_matrix(x))) \ x
+sp_ltriag_ldiv(x::VecOrMat) = LowerTriangular(sparse(test_matrix(x))) \ x
 
 const VECTOR_TO_VECTOR_FUNCS = (diag_lmul, dense_lmul, utriag_lmul, ltriag_lmul,
-                                diag_ldiv, utriag_ldiv, ltriag_ldiv)
+                                sparse_lmul, sp_utriag_lmul, sp_ltriag_lmul,
+                                diag_ldiv, utriag_ldiv, ltriag_ldiv,
+                                sparse_ldiv, sp_utriag_ldiv, sp_ltriag_ldiv,)
 
 ######################
 # f(x::Array)::Array #
@@ -309,6 +318,8 @@ const ARRAY_TO_ARRAY_FUNCS = (-, chebyquad, brown_almost_linear, trigonometric, 
 
 const MATRIX_TO_MATRIX_FUNCS = (inv,
                                 diag_lmul, dense_lmul, utriag_lmul, ltriag_lmul,
-                                diag_ldiv, utriag_ldiv, ltriag_ldiv)
+                                sparse_lmul, sp_utriag_lmul, sp_ltriag_lmul,
+                                diag_ldiv, utriag_ldiv, ltriag_ldiv,
+                                sparse_ldiv, sp_utriag_ldiv, sp_ltriag_ldiv,)
 
 end # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -35,11 +35,11 @@ for f in DiffTests.ARRAY_TO_ARRAY_FUNCS
 end
 
 for f in DiffTests.MATRIX_TO_MATRIX_FUNCS
-    @test isa(f(A), Array)
+    @test isa(f(A), Matrix)
 end
 
 for f in DiffTests.BINARY_MATRIX_TO_MATRIX_FUNCS
-    @test isa(f(A, B), Array)
+    @test isa(f(A, B), Matrix)
 end
 
 # f! returns Nothing

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -34,6 +34,10 @@ for f in DiffTests.ARRAY_TO_ARRAY_FUNCS
     @test isa(f(y), Array)
 end
 
+for f in DiffTests.VECTOR_TO_VECTOR_FUNCS
+    @test isa(f(y), Vector)
+end
+
 for f in DiffTests.MATRIX_TO_MATRIX_FUNCS
     @test isa(f(A), Matrix)
 end


### PR DESCRIPTION
The PR adds `f(x) = A*x` and `f(x) = A\x` functions, where `A` is a constant matrix, and `x` is either a vector or a matrix.
For vector arguments, the new `VECTOR_TO_VECTOR_FUNCS` list of test functions is introduced.

The tested `A` matrices are: diagonal, dense, lower and upper triangular. The last three matrix types are represented by the [Lehmer matrix](https://en.wikipedia.org/wiki/Lehmer_matrix).

In particular, the `A\x` functions are useful to test the autodiff of multivariate normal distribution.
This PR would be required to properly test JuliaDiff/ForwardDiff.jl#589 (so when/if merged, the version number of *DiffTools.jl* has to be updated).
